### PR TITLE
If no realm is reported, default to empty string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Paw-DigestAuthDynamicValue",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/DigestAuthDynamicValue.js",
   "license": "MIT",
   "homepage": "https://github.com/luckymarmot/Paw-DigestAuthDynamicValue",

--- a/src/HTTPDigestAuth.js
+++ b/src/HTTPDigestAuth.js
@@ -114,7 +114,7 @@ export default class HTTPDigestAuth {
     const method = this.method
     const url = this.url
 
-    const realm = this.chal['realm']
+    const realm = this.chal['realm'] ? this.chal['realm'] : ''
     const nonce = this.chal['nonce']
     const qop = this.chal['qop']
     const algorithm = this.chal['algorithm']


### PR DESCRIPTION
I ran into a problem when crafting SOAP requests. The plugin reported `realm="undefined"`, but the server expected `realm=""`.

Added check for undefined value for realm. 